### PR TITLE
[Suggestion] Keep both problem parts in the same file

### DIFF
--- a/src/1/solution.js
+++ b/src/1/solution.js
@@ -1,7 +1,15 @@
 // const {compose: c} = require('ramda');
 
-module.exports = inputLines => {
+const solution1 = inputLines => {
   // TODO: implement the solution;
 
   return inputLines;
 };
+
+const solution2 = inputLines => {
+    // TODO: implement the solution for the 2nd part;
+  
+    return inputLines;
+};
+
+module.exports = [solution1, solution2];

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,6 @@ const readFile = promisify(fs.readFile);
 const getLines = c(init, split('\n'));
 
 const [, , day, isSecond] = process.argv;
-const fn = require(`./${day}/solution${isSecond ? 2 : ''}`);
+const fn = require(`./${day}/solution`)[isSecond ? 1 : 0];
 
 readFile(`./${day}/input`, 'utf-8').then(c(log, fn, getLines));


### PR DESCRIPTION
I made a change in my fork so I don't have to create two files (solution.js and solution2.js) for the same problem, by keeping both solutions in the same file and exporting them in a tuple.

That was because I like solving the problem using different approaches, and it was getting a bit confusing if I wanted to keep every version. Now I can have one file per each different approach, and `solution.js` just forwards to the one I want to test.


Just sharing this in case you want to merge :)
