### PR TITLE
Support rxjs streams as solutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "dependencies": {
     "priorityqueuejs": "^1.0.0",
-    "ramda": "^0.26.0"
+    "ramda": "^0.26.0",
+    "rxjs": "^6.3.3"
   },
   "devDependencies": {
     "cross-env": "^5.2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,14 @@
 const {compose: c, init, split} = require('ramda');
 const {promisify} = require('util');
 const fs = require('fs');
+const { isObservable } = require('rxjs');
 
-const {log} = console;
+const log = v => {
+    if(isObservable(v)) {
+        return v.subscribe(console.log, console.error);
+    }
+    console.log(v);
+}
 const readFile = promisify(fs.readFile);
 const getLines = c(init, split('\n'));
 


### PR DESCRIPTION
I made a change in my fork so that I can export my solution as a rxjs stream - If that's the case, then index.js subscribes to that stream to log the result out.


Just sharing this in case you want to merge - Might be useful if you ever want to try rxjs :)
